### PR TITLE
Support both tokio and futures, via Cargo features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,16 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "jonhoo/async-bincode" }
 maintenance = { status = "passively-maintained" }
 
+[features]
+default = ["tokio"]
+
 [dependencies]
 bincode = "1.3.2"
 byteorder = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 serde = "1.0.8"
-tokio = { version = "1.0", features = ["net"] }
+tokio = { version = "1.0", features = ["net"], optional = true }
 bytes = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-bincode"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2018"
 
 description = "Asynchronous access to a bincode-encoded item stream."
@@ -19,22 +19,28 @@ categories = ["asynchronous", "encoding", "network-programming"]
 
 license = "MIT/Apache-2.0"
 
+[package.metadata.docs.rs]
+all-features = true
+
 [badges]
 travis-ci = { repository = "jonhoo/async-bincode" }
 maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["tokio"]
+futures = ["futures-io"]
 
 [dependencies]
 bincode = "1.3.2"
 byteorder = "1.0.0"
 futures-core = "0.3.0"
+futures-io = { version = "0.3.21", optional = true }
 futures-sink = "0.3.0"
 serde = "1.0.8"
 tokio = { version = "1.0", features = ["net"], optional = true }
 bytes = "1.0"
 
 [dev-dependencies]
+async-std = { version = "1.11.0", features = ["attributes"] }
 futures = "0.3.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/src/futures.rs
+++ b/src/futures.rs
@@ -1,0 +1,18 @@
+//! Asynchronous access to a bincode-encoded item stream using `futures_io`. See the top-level
+//! documentation and the documentation for [`AsyncBincodeReader`], [`AsyncBincodeWriter`], and
+//! [`AsyncBincodeStream`].
+
+make_reader!(futures_io::AsyncRead, internal_poll_reader);
+make_writer!(futures_io::AsyncWrite, poll_close);
+make_stream!(futures_io::AsyncRead, futures_io::AsyncWrite, [u8], usize);
+
+fn internal_poll_reader<R>(
+    r: std::pin::Pin<&mut R>,
+    cx: &mut std::task::Context,
+    rest: &mut [u8],
+) -> std::task::Poll<std::io::Result<usize>>
+where
+    R: futures_io::AsyncRead + Unpin,
+{
+    r.poll_read(cx, rest)
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,20 +10,104 @@
 //!
 //! On the write side, `async-bincode` buffers the serialized values, and asynchronously sends the
 //! resulting bytestream.
+//!
+//! This crate provides two sets of types in two separate modules. The types in the `futures`
+//! module work with the `futures_io`/`async-std` ecosystem. The types in the `tokio` module work
+//! with the `tokio` ecosystem.
 #![deny(missing_docs)]
+#[cfg(not(any(feature = "futures", feature = "tokio")))]
+compile_error!("async-bincode: Enable at least one of \"futures\" or \"tokio\".");
 
+#[macro_use]
 mod reader;
+#[macro_use]
 mod stream;
+#[macro_use]
 mod writer;
 
-pub use crate::reader::AsyncBincodeReader;
-pub use crate::stream::AsyncBincodeStream;
-pub use crate::writer::AsyncBincodeWriter;
+#[cfg(feature = "futures")]
+pub mod futures;
+#[cfg(feature = "tokio")]
+pub mod tokio;
+
+// Re-export for compatibility with the async-bincode 0.6 series.
+#[cfg(feature = "tokio")]
+pub use crate::tokio::{AsyncBincodeReader, AsyncBincodeStream, AsyncBincodeWriter};
+
 pub use crate::writer::{AsyncDestination, BincodeWriterFor, SyncDestination};
+
+#[cfg(all(test, feature = "futures"))]
+mod futures_tests {
+    use crate::futures::*;
+    use ::futures::prelude::*;
+
+    #[async_std::test]
+    async fn it_works() {
+        let echo = async_std::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let addr = echo.local_addr().unwrap();
+
+        async_std::task::spawn(async move {
+            let (stream, _) = echo.accept().await.unwrap();
+            let mut stream = AsyncBincodeStream::<_, usize, usize, _>::from(stream).for_async();
+            while let Some(item) = stream.next().await {
+                stream.send(item.unwrap()).await.unwrap();
+            }
+        });
+
+        let client = async_std::net::TcpStream::connect(&addr).await.unwrap();
+        let mut client = AsyncBincodeStream::<_, usize, usize, _>::from(client).for_async();
+        client.send(42).await.unwrap();
+        assert_eq!(client.next().await.unwrap().unwrap(), 42);
+
+        client.send(44).await.unwrap();
+        assert_eq!(client.next().await.unwrap().unwrap(), 44);
+
+        drop(client);
+    }
+
+    #[async_std::test]
+    async fn lots() {
+        let echo = async_std::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let addr = echo.local_addr().unwrap();
+
+        async_std::task::spawn(async move {
+            let (stream, _) = echo.accept().await.unwrap();
+            let mut stream = AsyncBincodeStream::<_, usize, usize, _>::from(stream).for_async();
+            while let Some(item) = stream.next().await {
+                stream.send(item.unwrap()).await.unwrap();
+            }
+        });
+
+        let n = 81920;
+        let stream = async_std::net::TcpStream::connect(&addr).await.unwrap();
+        let mut c = AsyncBincodeStream::from(stream).for_async();
+
+        ::futures::stream::iter(0usize..n)
+            .map(Ok)
+            .forward(&mut c)
+            .await
+            .unwrap();
+
+        c.get_mut()
+            .shutdown(async_std::net::Shutdown::Write)
+            .unwrap();
+
+        let mut at = 0;
+        while let Some(got) = c.next().await.transpose().unwrap() {
+            assert_eq!(at, got);
+            at += 1;
+        }
+        assert_eq!(at, n);
+    }
+}
 
 #[cfg(all(test, feature = "tokio"))]
 mod tokio_tests {
-    use super::*;
+    use crate::tokio::*;
     use futures::prelude::*;
     use tokio::io::AsyncWriteExt;
 
@@ -66,7 +150,7 @@ mod tokio_tests {
         let stream = tokio::net::TcpStream::connect(&addr).await.unwrap();
         let mut c = AsyncBincodeStream::from(stream).for_async();
 
-        futures::stream::iter(0usize..n)
+        ::futures::stream::iter(0usize..n)
             .map(Ok)
             .forward(&mut c)
             .await

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use crate::stream::AsyncBincodeStream;
 pub use crate::writer::AsyncBincodeWriter;
 pub use crate::writer::{AsyncDestination, BincodeWriterFor, SyncDestination};
 
-#[cfg(test)]
-mod tests {
+#[cfg(all(test, feature = "tokio"))]
+mod tokio_tests {
     use super::*;
     use futures::prelude::*;
     use tokio::io::AsyncWriteExt;

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -1,0 +1,61 @@
+//! Asynchronous access to a bincode-encoded item stream using `tokio`. See the top-level
+//! documentation and the documentation for [`AsyncBincodeReader`], [`AsyncBincodeWriter`], and
+//! [`AsyncBincodeStream`].
+
+make_reader!(tokio::io::AsyncRead, internal_poll_reader);
+make_writer!(tokio::io::AsyncWrite, poll_shutdown);
+make_stream!(
+    tokio::io::AsyncRead,
+    tokio::io::AsyncWrite,
+    tokio::io::ReadBuf,
+    ()
+);
+
+fn internal_poll_reader<R>(
+    r: std::pin::Pin<&mut R>,
+    cx: &mut std::task::Context,
+    rest: &mut [u8],
+) -> std::task::Poll<std::io::Result<usize>>
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    let mut buf = tokio::io::ReadBuf::new(rest);
+    futures_core::ready!(r.poll_read(cx, &mut buf))?;
+    let n = buf.filled().len();
+    std::task::Poll::Ready(Ok(n))
+}
+
+impl<R, W, D> AsyncBincodeStream<tokio::net::TcpStream, R, W, D> {
+    /// Split a TCP-based stream into a read half and a write half.
+    ///
+    /// This is more performant than using a lock-based split like the one provided by `tokio-io`
+    /// or `futures-util` since we know that reads and writes to a `TcpStream` can continue
+    /// concurrently.
+    ///
+    /// Any partially sent or received state is preserved.
+    pub fn tcp_split(
+        &mut self,
+    ) -> (
+        AsyncBincodeReader<tokio::net::tcp::ReadHalf, R>,
+        AsyncBincodeWriter<tokio::net::tcp::WriteHalf, W, D>,
+    ) {
+        // First, steal the reader state so it isn't lost
+        let rbuff = self.stream.0.buffer.split();
+        // Then, fish out the writer
+        let writer = &mut self.stream.get_mut().0;
+        // And steal the writer state so it isn't lost
+        let wbuff = writer.buffer.split_off(0);
+        let wsize = writer.written;
+        // Now split the stream
+        let (r, w) = writer.get_mut().split();
+        // Then put the reader back together
+        let mut reader = AsyncBincodeReader::from(r);
+        reader.0.buffer = rbuff;
+        // And then the writer
+        let mut writer: AsyncBincodeWriter<_, _, D> = AsyncBincodeWriter::from(w).make_for();
+        writer.buffer = wbuff;
+        writer.written = wsize;
+        // All good!
+        (reader, writer)
+    }
+}

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,12 +6,14 @@ use serde::Serialize;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::AsyncWrite;
 
 /// A wrapper around an asynchronous sink that accepts, serializes, and sends bincode-encoded
 /// values.
 ///
-/// To use, provide a writer that implements [`AsyncWrite`], and then use [`Sink`] to send values.
+/// To use, provide an async writer and then use [`Sink`] to send values.
+///
+/// The async writer type must implement one of the following traits:
+#[cfg_attr(feature = "tokio", doc = "- [`tokio::io::AsyncWrite`]")]
 ///
 /// Note that an `AsyncBincodeWriter` must be of the type [`AsyncDestination`] in order to be
 /// compatible with an [`AsyncBincodeReader`] on the remote end (recall that it requires the
@@ -138,10 +140,11 @@ where
     }
 }
 
+#[cfg(feature = "tokio")]
 impl<W, T, D> Sink<T> for AsyncBincodeWriter<W, T, D>
 where
     T: Serialize,
-    W: AsyncWrite + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
     Self: BincodeWriterFor<T>,
 {
     type Error = bincode::Error;

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -1,107 +1,191 @@
-use bincode::Options;
-use byteorder::{NetworkEndian, WriteBytesExt};
-use futures_core::ready;
-use futures_sink::Sink;
-use serde::Serialize;
-use std::marker::PhantomData;
-use std::pin::Pin;
-use std::task::{Context, Poll};
+macro_rules! make_writer {
+    ($write_trait:path, $poll_close_method:ident) => {
+        pub use crate::writer::{AsyncDestination, BincodeWriterFor, SyncDestination};
 
-/// A wrapper around an asynchronous sink that accepts, serializes, and sends bincode-encoded
-/// values.
-///
-/// To use, provide an async writer and then use [`Sink`] to send values.
-///
-/// The async writer type must implement one of the following traits:
-#[cfg_attr(feature = "tokio", doc = "- [`tokio::io::AsyncWrite`]")]
-///
-/// Note that an `AsyncBincodeWriter` must be of the type [`AsyncDestination`] in order to be
-/// compatible with an [`AsyncBincodeReader`] on the remote end (recall that it requires the
-/// serialized size prefixed to the serialized data). The default is [`SyncDestination`], but these
-/// can be easily toggled between using [`AsyncBincodeWriter::for_async`].
-#[derive(Debug)]
-pub struct AsyncBincodeWriter<W, T, D> {
-    writer: W,
-    pub(crate) written: usize,
-    pub(crate) buffer: Vec<u8>,
-    from: PhantomData<T>,
-    dest: PhantomData<D>,
-}
-
-impl<W, T, D> Unpin for AsyncBincodeWriter<W, T, D> where W: Unpin {}
-
-impl<W, T> Default for AsyncBincodeWriter<W, T, SyncDestination>
-where
-    W: Default,
-{
-    fn default() -> Self {
-        Self::from(W::default())
-    }
-}
-
-impl<W, T, D> AsyncBincodeWriter<W, T, D> {
-    /// Gets a reference to the underlying writer.
-    ///
-    /// It is inadvisable to directly write to the underlying writer.
-    pub fn get_ref(&self) -> &W {
-        &self.writer
-    }
-
-    /// Gets a mutable reference to the underlying writer.
-    ///
-    /// It is inadvisable to directly write to the underlying writer.
-    pub fn get_mut(&mut self) -> &mut W {
-        &mut self.writer
-    }
-
-    /// Unwraps this `AsyncBincodeWriter`, returning the underlying writer.
-    ///
-    /// Note that any leftover serialized data that has not yet been sent is lost.
-    pub fn into_inner(self) -> W {
-        self.writer
-    }
-}
-
-impl<W, T> From<W> for AsyncBincodeWriter<W, T, SyncDestination> {
-    fn from(writer: W) -> Self {
-        AsyncBincodeWriter {
-            buffer: Vec::new(),
-            writer,
-            written: 0,
-            from: PhantomData,
-            dest: PhantomData,
+        /// A wrapper around an asynchronous sink that accepts, serializes, and sends bincode-encoded
+        /// values.
+        ///
+        /// To use, provide a reader that implements
+        #[doc=concat!("[`", stringify!($write_trait), "`],")]
+        /// and then use [`futures_sink::Sink`] to send values.
+        ///
+        /// Note that an `AsyncBincodeWriter` must be of the type [`AsyncDestination`] in order to be
+        /// compatible with an [`AsyncBincodeReader`] on the remote end (recall that it requires the
+        /// serialized size prefixed to the serialized data). The default is [`SyncDestination`], but these
+        /// can be easily toggled between using [`AsyncBincodeWriter::for_async`].
+        #[derive(Debug)]
+        pub struct AsyncBincodeWriter<W, T, D> {
+            pub(crate) writer: W,
+            pub(crate) written: usize,
+            pub(crate) buffer: Vec<u8>,
+            pub(crate) from: std::marker::PhantomData<T>,
+            pub(crate) dest: std::marker::PhantomData<D>,
         }
-    }
-}
 
-impl<W, T> AsyncBincodeWriter<W, T, SyncDestination> {
-    /// Make this writer include the serialized data's size before each serialized value.
-    ///
-    /// This is necessary for compatability with [`AsyncBincodeReader`].
-    pub fn for_async(self) -> AsyncBincodeWriter<W, T, AsyncDestination> {
-        self.make_for()
-    }
-}
+        impl<W, T, D> Unpin for AsyncBincodeWriter<W, T, D> where W: Unpin {}
 
-impl<W, T, D> AsyncBincodeWriter<W, T, D> {
-    pub(crate) fn make_for<D2>(self) -> AsyncBincodeWriter<W, T, D2> {
-        AsyncBincodeWriter {
-            buffer: self.buffer,
-            writer: self.writer,
-            written: self.written,
-            from: self.from,
-            dest: PhantomData,
+        impl<W, T> Default for AsyncBincodeWriter<W, T, SyncDestination>
+        where
+            W: Default,
+        {
+            fn default() -> Self {
+                Self::from(W::default())
+            }
         }
-    }
-}
 
-impl<W, T> AsyncBincodeWriter<W, T, AsyncDestination> {
-    /// Make this writer only send bincode-encoded values.
-    ///
-    /// This is necessary for compatability with stock `bincode` receivers.
-    pub fn for_sync(self) -> AsyncBincodeWriter<W, T, SyncDestination> {
-        self.make_for()
-    }
+        impl<W, T, D> AsyncBincodeWriter<W, T, D> {
+            /// Gets a reference to the underlying writer.
+            ///
+            /// It is inadvisable to directly write to the underlying writer.
+            pub fn get_ref(&self) -> &W {
+                &self.writer
+            }
+
+            /// Gets a mutable reference to the underlying writer.
+            ///
+            /// It is inadvisable to directly write to the underlying writer.
+            pub fn get_mut(&mut self) -> &mut W {
+                &mut self.writer
+            }
+
+            /// Unwraps this `AsyncBincodeWriter`, returning the underlying writer.
+            ///
+            /// Note that any leftover serialized data that has not yet been sent is lost.
+            pub fn into_inner(self) -> W {
+                self.writer
+            }
+        }
+
+        impl<W, T> From<W> for AsyncBincodeWriter<W, T, SyncDestination> {
+            fn from(writer: W) -> Self {
+                Self {
+                    buffer: Vec::new(),
+                    writer,
+                    written: 0,
+                    from: std::marker::PhantomData,
+                    dest: std::marker::PhantomData,
+                }
+            }
+        }
+
+        impl<W, T> AsyncBincodeWriter<W, T, SyncDestination> {
+            /// Make this writer include the serialized data's size before each serialized value.
+            ///
+            /// This is necessary for compatibility with [`AsyncBincodeReader`].
+            pub fn for_async(self) -> AsyncBincodeWriter<W, T, AsyncDestination> {
+                self.make_for()
+            }
+        }
+
+        impl<W, T> AsyncBincodeWriter<W, T, AsyncDestination> {
+            /// Make this writer only send bincode-encoded values.
+            ///
+            /// This is necessary for compatibility with stock `bincode` receivers.
+            pub fn for_sync(self) -> AsyncBincodeWriter<W, T, SyncDestination> {
+                self.make_for()
+            }
+        }
+
+        impl<W, T, D> AsyncBincodeWriter<W, T, D> {
+            pub(crate) fn make_for<D2>(self) -> AsyncBincodeWriter<W, T, D2> {
+                AsyncBincodeWriter {
+                    buffer: self.buffer,
+                    writer: self.writer,
+                    written: self.written,
+                    from: self.from,
+                    dest: std::marker::PhantomData,
+                }
+            }
+        }
+
+        impl<W, T> BincodeWriterFor<T> for AsyncBincodeWriter<W, T, AsyncDestination>
+        where
+            T: serde::Serialize,
+        {
+            fn append(&mut self, item: T) -> Result<(), bincode::Error> {
+                use bincode::Options;
+                use byteorder::{NetworkEndian, WriteBytesExt};
+                let c = bincode::options()
+                    .with_limit(u32::max_value() as u64)
+                    .allow_trailing_bytes();
+                let size = c.serialized_size(&item)? as u32;
+                self.buffer.write_u32::<NetworkEndian>(size)?;
+                c.serialize_into(&mut self.buffer, &item)
+            }
+        }
+
+        impl<W, T> BincodeWriterFor<T> for AsyncBincodeWriter<W, T, SyncDestination>
+        where
+            T: serde::Serialize,
+        {
+            fn append(&mut self, item: T) -> Result<(), bincode::Error> {
+                bincode::serialize_into(&mut self.buffer, &item)
+            }
+        }
+
+        impl<W, T, D> futures_sink::Sink<T> for AsyncBincodeWriter<W, T, D>
+        where
+            T: serde::Serialize,
+            W: $write_trait + Unpin,
+            Self: BincodeWriterFor<T>,
+        {
+            type Error = bincode::Error;
+
+            fn poll_ready(
+                self: std::pin::Pin<&mut Self>,
+                _: &mut std::task::Context,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                std::task::Poll::Ready(Ok(()))
+            }
+
+            fn start_send(mut self: std::pin::Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
+                if self.buffer.is_empty() {
+                    // NOTE: in theory we could have a short-circuit here that tries to have bincode write
+                    // directly into self.writer. this would be way more efficient in the common case as we
+                    // don't have to do the extra buffering. the idea would be to serialize fist, and *if*
+                    // it errors, see how many bytes were written, serialize again into a Vec, and then
+                    // keep only the bytes following the number that were written in our buffer.
+                    // unfortunately, bincode will not tell us that number at the moment, and instead just
+                    // fail.
+                }
+
+                self.append(item)?;
+                Ok(())
+            }
+
+            fn poll_flush(
+                self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                // allow us to borrow fields separately
+                let this = self.get_mut();
+
+                // write stuff out if we need to
+                while this.written != this.buffer.len() {
+                    let n = futures_core::ready!(std::pin::Pin::new(&mut this.writer)
+                        .poll_write(cx, &this.buffer[this.written..]))?;
+                    this.written += n;
+                }
+
+                // we have to flush before we're really done
+                this.buffer.clear();
+                this.written = 0;
+                std::pin::Pin::new(&mut this.writer)
+                    .poll_flush(cx)
+                    .map_err(bincode::Error::from)
+            }
+
+            fn poll_close(
+                mut self: std::pin::Pin<&mut Self>,
+                cx: &mut std::task::Context,
+            ) -> std::task::Poll<Result<(), Self::Error>> {
+                futures_core::ready!(self.as_mut().poll_flush(cx))?;
+                std::pin::Pin::new(&mut self.writer)
+                    .$poll_close_method(cx)
+                    .map_err(bincode::Error::from)
+            }
+        }
+    };
 }
 
 /// A marker that indicates that the wrapping type is compatible with `AsyncBincodeReader`.
@@ -115,82 +199,4 @@ pub struct SyncDestination;
 #[doc(hidden)]
 pub trait BincodeWriterFor<T> {
     fn append(&mut self, item: T) -> Result<(), bincode::Error>;
-}
-
-impl<W, T> BincodeWriterFor<T> for AsyncBincodeWriter<W, T, AsyncDestination>
-where
-    T: Serialize,
-{
-    fn append(&mut self, item: T) -> Result<(), bincode::Error> {
-        let c = bincode::options()
-            .with_limit(u32::max_value() as u64)
-            .allow_trailing_bytes();
-        let size = c.serialized_size(&item)? as u32;
-        self.buffer.write_u32::<NetworkEndian>(size)?;
-        c.serialize_into(&mut self.buffer, &item)
-    }
-}
-
-impl<W, T> BincodeWriterFor<T> for AsyncBincodeWriter<W, T, SyncDestination>
-where
-    T: Serialize,
-{
-    fn append(&mut self, item: T) -> Result<(), bincode::Error> {
-        bincode::serialize_into(&mut self.buffer, &item)
-    }
-}
-
-#[cfg(feature = "tokio")]
-impl<W, T, D> Sink<T> for AsyncBincodeWriter<W, T, D>
-where
-    T: Serialize,
-    W: tokio::io::AsyncWrite + Unpin,
-    Self: BincodeWriterFor<T>,
-{
-    type Error = bincode::Error;
-
-    fn poll_ready(self: Pin<&mut Self>, _: &mut Context) -> Poll<Result<(), Self::Error>> {
-        Poll::Ready(Ok(()))
-    }
-
-    fn start_send(mut self: Pin<&mut Self>, item: T) -> Result<(), Self::Error> {
-        if self.buffer.is_empty() {
-            // NOTE: in theory we could have a short-circuit here that tries to have bincode write
-            // directly into self.writer. this would be way more efficient in the common case as we
-            // don't have to do the extra buffering. the idea would be to serialize fist, and *if*
-            // it errors, see how many bytes were written, serialize again into a Vec, and then
-            // keep only the bytes following the number that were written in our buffer.
-            // unfortunately, bincode will not tell us that number at the moment, and instead just
-            // fail.
-        }
-
-        self.append(item)?;
-        Ok(())
-    }
-
-    fn poll_flush(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        // allow us to borrow fields separately
-        let this = self.get_mut();
-
-        // write stuff out if we need to
-        while this.written != this.buffer.len() {
-            let n =
-                ready!(Pin::new(&mut this.writer).poll_write(cx, &this.buffer[this.written..]))?;
-            this.written += n;
-        }
-
-        // we have to flush before we're really done
-        this.buffer.clear();
-        this.written = 0;
-        Pin::new(&mut this.writer)
-            .poll_flush(cx)
-            .map_err(bincode::Error::from)
-    }
-
-    fn poll_close(mut self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {
-        ready!(self.as_mut().poll_flush(cx))?;
-        Pin::new(&mut self.writer)
-            .poll_shutdown(cx)
-            .map_err(bincode::Error::from)
-    }
 }


### PR DESCRIPTION
Make tokio dependency optional via a "tokio" feature, and add support for
futures via a "futures" feature.

This attempts to duplicate as little code as possible.

As implemented, exactly one of "futures" and "tokio" must be enabled; enabling
both produces an error due to conflicting implementations of the same traits.
Supporting both simultaneously would require substantially more duplication,
and two distinct families of types.
