### PR TITLE
Bump version to 0.7.0 and modify default features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-bincode"
-version = "0.6.1"
+version = "0.6.2"
 edition = "2018"
 
 description = "Asynchronous access to a bincode-encoded item stream."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "async-bincode"
-version = "0.6.2"
+version = "0.7.0"
 edition = "2018"
 
 description = "Asynchronous access to a bincode-encoded item stream."
@@ -24,7 +24,6 @@ travis-ci = { repository = "jonhoo/async-bincode" }
 maintenance = { status = "passively-maintained" }
 
 [features]
-default = ["tokio"]
 futures = ["futures-io"]
 
 [dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,13 +23,16 @@ license = "MIT/Apache-2.0"
 travis-ci = { repository = "jonhoo/async-bincode" }
 maintenance = { status = "passively-maintained" }
 
+[features]
+default = ["tokio"]
+
 [dependencies]
 bincode = "1.3.2"
 byteorder = "1.0.0"
 futures-core = "0.3.0"
 futures-sink = "0.3.0"
 serde = "1.0.8"
-tokio = { version = "1.0", features = ["net"] }
+tokio = { version = "1.0", features = ["net"], optional = true }
 bytes = "1.0"
 
 [dev-dependencies]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,16 +25,19 @@ maintenance = { status = "passively-maintained" }
 
 [features]
 default = ["tokio"]
+futures = ["futures-io"]
 
 [dependencies]
 bincode = "1.3.2"
 byteorder = "1.0.0"
 futures-core = "0.3.0"
+futures-io = { version = "0.3.21", optional = true }
 futures-sink = "0.3.0"
 serde = "1.0.8"
 tokio = { version = "1.0", features = ["net"], optional = true }
 bytes = "1.0"
 
 [dev-dependencies]
+async-std = { version = "1.11.0", features = ["attributes"] }
 futures = "0.3.0"
 tokio = { version = "1.0", features = ["full"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -21,8 +21,8 @@ pub use crate::stream::AsyncBincodeStream;
 pub use crate::writer::AsyncBincodeWriter;
 pub use crate::writer::{AsyncDestination, BincodeWriterFor, SyncDestination};
 
-#[cfg(test)]
-mod tests {
+#[cfg(all(test, feature = "tokio"))]
+mod tokio_tests {
     use super::*;
     use futures::prelude::*;
     use tokio::io::AsyncWriteExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -11,6 +11,10 @@
 //! On the write side, `async-bincode` buffers the serialized values, and asynchronously sends the
 //! resulting bytestream.
 #![deny(missing_docs)]
+#[cfg(not(any(feature = "futures", feature = "tokio")))]
+compile_error!("async-bincode: Enable at least one of \"futures\" or \"tokio\".");
+#[cfg(all(feature = "futures", feature = "tokio"))]
+compile_error!("async-bincode: Enable at most one of \"futures\" or \"tokio\".");
 
 mod reader;
 mod stream;
@@ -20,6 +24,75 @@ pub use crate::reader::AsyncBincodeReader;
 pub use crate::stream::AsyncBincodeStream;
 pub use crate::writer::AsyncBincodeWriter;
 pub use crate::writer::{AsyncDestination, BincodeWriterFor, SyncDestination};
+
+#[cfg(all(test, feature = "futures"))]
+mod futures_tests {
+    use super::*;
+    use futures::prelude::*;
+
+    #[async_std::test]
+    async fn it_works() {
+        let echo = async_std::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let addr = echo.local_addr().unwrap();
+
+        async_std::task::spawn(async move {
+            let (stream, _) = echo.accept().await.unwrap();
+            let mut stream = AsyncBincodeStream::<_, usize, usize, _>::from(stream).for_async();
+            while let Some(item) = stream.next().await {
+                stream.send(item.unwrap()).await.unwrap();
+            }
+        });
+
+        let client = async_std::net::TcpStream::connect(&addr).await.unwrap();
+        let mut client = AsyncBincodeStream::<_, usize, usize, _>::from(client).for_async();
+        client.send(42).await.unwrap();
+        assert_eq!(client.next().await.unwrap().unwrap(), 42);
+
+        client.send(44).await.unwrap();
+        assert_eq!(client.next().await.unwrap().unwrap(), 44);
+
+        drop(client);
+    }
+
+    #[async_std::test]
+    async fn lots() {
+        let echo = async_std::net::TcpListener::bind("127.0.0.1:0")
+            .await
+            .unwrap();
+        let addr = echo.local_addr().unwrap();
+
+        async_std::task::spawn(async move {
+            let (stream, _) = echo.accept().await.unwrap();
+            let mut stream = AsyncBincodeStream::<_, usize, usize, _>::from(stream).for_async();
+            while let Some(item) = stream.next().await {
+                stream.send(item.unwrap()).await.unwrap();
+            }
+        });
+
+        let n = 81920;
+        let stream = async_std::net::TcpStream::connect(&addr).await.unwrap();
+        let mut c = AsyncBincodeStream::from(stream).for_async();
+
+        futures::stream::iter(0usize..n)
+            .map(Ok)
+            .forward(&mut c)
+            .await
+            .unwrap();
+
+        c.get_mut()
+            .shutdown(async_std::net::Shutdown::Write)
+            .unwrap();
+
+        let mut at = 0;
+        while let Some(got) = c.next().await.transpose().unwrap() {
+            assert_eq!(at, got);
+            at += 1;
+        }
+        assert_eq!(at, n);
+    }
+}
 
 #[cfg(all(test, feature = "tokio"))]
 mod tokio_tests {

--- a/src/stream.rs
+++ b/src/stream.rs
@@ -14,6 +14,10 @@ use std::{fmt, io};
 ///
 /// The stream type should implement one of the following combinations of traits:
 #[cfg_attr(
+    feature = "futures",
+    doc = "- [`futures_io::AsyncRead`] and [`futures_io::AsyncWrite`]"
+)]
+#[cfg_attr(
     feature = "tokio",
     doc = "- [`tokio::io::AsyncRead`] and [`tokio::io::AsyncWrite`]"
 )]
@@ -131,6 +135,20 @@ impl<R, W, D> AsyncBincodeStream<tokio::net::TcpStream, R, W, D> {
         writer.written = wsize;
         // All good!
         (reader, writer)
+    }
+}
+
+#[cfg(feature = "futures")]
+impl<S, T, D> futures_io::AsyncRead for InternalAsyncWriter<S, T, D>
+where
+    S: futures_io::AsyncRead + Unpin,
+{
+    fn poll_read(
+        self: Pin<&mut Self>,
+        cx: &mut Context,
+        buf: &mut [u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        Pin::new(self.get_mut().get_mut()).poll_read(cx, buf)
     }
 }
 

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -6,12 +6,14 @@ use serde::Serialize;
 use std::marker::PhantomData;
 use std::pin::Pin;
 use std::task::{Context, Poll};
-use tokio::io::AsyncWrite;
 
 /// A wrapper around an asynchronous sink that accepts, serializes, and sends bincode-encoded
 /// values.
 ///
-/// To use, provide a writer that implements [`AsyncWrite`], and then use [`Sink`] to send values.
+/// To use, provide an async writer and then use [`Sink`] to send values.
+///
+/// The async writer type must implement one of the following traits:
+#[cfg_attr(feature = "tokio", doc = "- [`tokio::io::AsyncWrite`]")]
 ///
 /// Note that an `AsyncBincodeWriter` must be of the type [`AsyncDestination`] in order to be
 /// compatible with an [`AsyncBincodeReader`] on the remote end (recall that it requires the
@@ -138,10 +140,11 @@ where
     }
 }
 
+#[cfg(feature = "tokio")]
 impl<W, T, D> Sink<T> for AsyncBincodeWriter<W, T, D>
 where
     T: Serialize,
-    W: AsyncWrite + Unpin,
+    W: tokio::io::AsyncWrite + Unpin,
     Self: BincodeWriterFor<T>,
 {
     type Error = bincode::Error;


### PR DESCRIPTION
This makes it easy for library crates to depend on async-bincode without having
to explicitly use `default-features = false`; libraries and applications that
want to select an ecosystem can then enable the corresponding feature.
