### PR TITLE
Add trait bounds to Default and From impls

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -29,14 +29,19 @@ macro_rules! make_reader {
 
         impl<R, T> Default for AsyncBincodeReader<R, T>
         where
-            R: Default,
+            for<'a> T: ::serde::Deserialize<'a>,
+            R: Default + $read_trait + Unpin,
         {
             fn default() -> Self {
                 Self::from(R::default())
             }
         }
 
-        impl<R, T> From<R> for AsyncBincodeReader<R, T> {
+        impl<R, T> From<R> for AsyncBincodeReader<R, T>
+        where
+            for<'a> T: ::serde::Deserialize<'a>,
+            R: $read_trait + Unpin,
+        {
             fn from(reader: R) -> Self {
                 Self(crate::reader::AsyncBincodeReader {
                     buffer: ::bytes::BytesMut::with_capacity(8192),

--- a/src/tokio.rs
+++ b/src/tokio.rs
@@ -49,12 +49,19 @@ impl<R, W, D> AsyncBincodeStream<tokio::net::TcpStream, R, W, D> {
         // Now split the stream
         let (r, w) = writer.get_mut().split();
         // Then put the reader back together
-        let mut reader = AsyncBincodeReader::from(r);
-        reader.0.buffer = rbuff;
+        let reader = AsyncBincodeReader(crate::reader::AsyncBincodeReader {
+            buffer: rbuff,
+            reader: r,
+            into: std::marker::PhantomData,
+        });
         // And then the writer
-        let mut writer: AsyncBincodeWriter<_, _, D> = AsyncBincodeWriter::from(w).make_for();
-        writer.buffer = wbuff;
-        writer.written = wsize;
+        let writer: AsyncBincodeWriter<_, _, D> = AsyncBincodeWriter {
+            buffer: wbuff,
+            writer: w,
+            written: wsize,
+            dest: std::marker::PhantomData,
+            from: std::marker::PhantomData,
+        };
         // All good!
         (reader, writer)
     }

--- a/src/writer.rs
+++ b/src/writer.rs
@@ -29,7 +29,8 @@ macro_rules! make_writer {
 
         impl<W, T> Default for AsyncBincodeWriter<W, T, SyncDestination>
         where
-            W: Default,
+            T: serde::Serialize,
+            W: Default + $write_trait + Unpin,
         {
             fn default() -> Self {
                 Self::from(W::default())
@@ -59,7 +60,11 @@ macro_rules! make_writer {
             }
         }
 
-        impl<W, T> From<W> for AsyncBincodeWriter<W, T, SyncDestination> {
+        impl<W, T> From<W> for AsyncBincodeWriter<W, T, SyncDestination>
+        where
+            T: serde::Serialize,
+            W: $write_trait + Unpin,
+        {
             fn from(writer: W) -> Self {
                 Self {
                     buffer: Vec::new(),


### PR DESCRIPTION
This should allow making the correct usage of the crate much more easily discoverable, while not adding too many bounds to unrelated functions.

Fixes #3.