### PR TITLE
Avoid discarding capacity during read operation

### DIFF
--- a/src/reader.rs
+++ b/src/reader.rs
@@ -182,7 +182,9 @@ where
                                 if self.buffer.is_empty() {
                                     return Poll::Ready(Ok(FillResult::EOF));
                                 } else {
-                                    return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+                                    return Poll::Ready(Err(io::Error::from(
+                                        io::ErrorKind::BrokenPipe,
+                                    )));
                                 }
                             }
 

--- a/src/reader.rs
+++ b/src/reader.rs
@@ -174,18 +174,29 @@ where
         unsafe { rest.set_len(max) };
 
         while self.buffer.len() < target_size {
-            let n = ready!(poll_reader(Pin::new(&mut self.reader), cx, &mut rest[..]))?;
-            if n == 0 {
-                if self.buffer.is_empty() {
-                    return Poll::Ready(Ok(FillResult::EOF));
-                } else {
-                    return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+            match poll_reader(Pin::new(&mut self.reader), cx, &mut rest[..]) {
+                Poll::Ready(result) => {
+                    let n = result?;
+
+                    if n == 0 {
+                        if self.buffer.is_empty() {
+                            return Poll::Ready(Ok(FillResult::EOF));
+                        } else {
+                            return Poll::Ready(Err(io::Error::from(io::ErrorKind::BrokenPipe)));
+                        }
+                    }
+
+                    // adopt the new bytes
+                    let read = rest.split_to(n);
+                    self.buffer.unsplit(read);
+                }
+                Poll::Pending => {
+                    // reading in progress, put the buffer back
+                    rest.truncate(0);
+                    self.buffer.unsplit(rest);
+                    return Poll::Pending;
                 }
             }
-
-            // adopt the new bytes
-            let read = rest.split_to(n);
-            self.buffer.unsplit(read);
         }
 
         Poll::Ready(Ok(FillResult::Filled))


### PR DESCRIPTION
The previous behaviour caused the target buffer length to change between calls within a single read operation, which seems wrong since the underlying read would then try to read too much into a smaller buffer